### PR TITLE
Add CI to do linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language:  node_js
+install:
+  - "npm install -g jshint"
+script:
+  - "jshint ."
+notifications:
+  irc:
+    channels:
+      - "irc.mozilla.org#diversibee"

--- a/js/profits.js
+++ b/js/profits.js
@@ -16,8 +16,7 @@
             }
         }
         return bees;
-
-    }
+    };
 
     window.Profits = Profits;
 })();

--- a/js/util.js
+++ b/js/util.js
@@ -34,7 +34,7 @@
         }
 
         return neighbours;
-    }
+    };
 
     Utils.inArray = function(needle, haystack) {
         //Determine if item is in array
@@ -48,8 +48,7 @@
             }
         }
         return false;
-    }
-
+    };
 
     window.Utils = Utils;
 })();


### PR DESCRIPTION
The continuous integration (CI) build is doing linting with [JSHint](http://jshint.com/) to check for potential problems. Later we might add actual tests.

@jvamosi will need to sign up on [TravisCi](https://travis-ci.org/), which just involves giving it some permissions for your GitHub account. Build notifications will be sent to our IRC channel (irc.mozilla.org#diversibee).