### PR TITLE
Fix bug in Lv3 profit calculation

### DIFF
--- a/js/stateManagement.js
+++ b/js/stateManagement.js
@@ -278,13 +278,13 @@ var Diversibee = (function() {
         // Calculate number of bee in surrounding cells
         neighbours.forEach(function(neighbourCell) {
           if (neighbourCell.type === cellTypes.forest) {
-            contribution += (1.0 / 7.0) * beesInCell[boardIndex(neighbourCell.coords)];
+            contribution += beesInCell[boardIndex(neighbourCell.coords)];
           }
         });
 
         // Calculate Profit for cell
-        if (contribution <= 1) {
-          cellProfit = 0.1 + (0.9 / 6.0) * contribution;
+        if (contribution < 7) {
+          cellProfit = 0.1 + (0.9 / 7.0) * contribution;
         } else {
           cellProfit = 1;
         }


### PR DESCRIPTION
The rise in profit from a berry bush should be linear as its
neighbouring contributors rise from 0 to 7, after which the profit is
capped. The formula specified for Level 3 in Issue #41 had an extra
divide by six, greatly reducing the value of bushes with less than 8
contributors. This left a sudden spike in value at 8 contributors.

This bug only affected bushes that did not have maxed-out contributor
counts. Because very easy to max-out contributor counts, the overall
impact of the bug on the game's strategy was limited.