### PR TITLE
Add MPL license header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html lang='en'>
   <head>
     <meta charset='UTF-8'>

--- a/js/profits.js
+++ b/js/profits.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global exports */
 var Profits = (function() {
   //functions describing how profits are caluclated for a given blueberry crop tile

--- a/js/stateManagement.js
+++ b/js/stateManagement.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global exports, Profits, World */
 
 var Diversibee = (function() {

--- a/js/tabBehavior.js
+++ b/js/tabBehavior.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 $(document).ready(function() {
 
   $('#tab-level1 a').click(function(e) {

--- a/js/util.js
+++ b/js/util.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 (function() {
   //helper functions and general utilities
 

--- a/js/world.js
+++ b/js/world.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global exports */
 var World = (function() {
   // Collection of class to work on the world, geometry....

--- a/tests/profits.js
+++ b/tests/profits.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global require */
 if (typeof (require) != 'undefined') {
   var Tests = require('./tests.js').Tests,

--- a/tests/tests-cli.js
+++ b/tests/tests-cli.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global require, process */
 var tests = require('./tests.js').Tests;
 require('./profits.js');

--- a/tests/tests-of-tests.js
+++ b/tests/tests-of-tests.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global require */
 if (typeof (require) != 'undefined') {
   var Tests = require('./tests.js').Tests;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global exports, require */
 if (typeof (require) != 'undefined') {
   var color = require('colors/safe');

--- a/tests/world.js
+++ b/tests/world.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global require */
 if (typeof (require) != 'undefined') {
   var Tests = require('./tests.js').Tests,


### PR DESCRIPTION
These headers are standard and expected for code licenced under the
MPL, because the license has implications on a per-file basis.
The headers should have been added along with #90.