### PR TITLE
Setup http://diversibee.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.diversibee.org


### PR DESCRIPTION
I registered the domain `diversibee.org`. It is set up such that you can visit via http://diversibee.org or http://www.diversibee.org. The www will be added if it's missing.

This CNAME file is required by GitHub Pages as per [their guide](https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/). Hopefully I didn't miss anything.