### PR TITLE
Add minimum multiplier of 0.1 for Lv1 Profit

### DIFF
--- a/js/profits.js
+++ b/js/profits.js
@@ -20,7 +20,7 @@ var Profits = (function() {
       }
     }
 
-    return blueberryCount * treeCount / 10;
+    return blueberryCount * Math.max(treeCount, 0.1) / 10;
   };
 
   Profits.calculateLv2Profit = function(board) {

--- a/tests/profits.js
+++ b/tests/profits.js
@@ -52,11 +52,11 @@ Tests.addSuite('profits', [
     board.cells[5].type = 'blueberries';
     Tests.equals(Profits.calculateLv1Profit(board), 0.6);
     board.cells[6].type = 'blueberries';
-    Tests.equals(Profits.calculateLv1Profit(board), 0.0);
+    Tests.equals(Profits.calculateLv1Profit(board), 0.07);
     board.cells[7].type = 'blueberries';
-    Tests.equals(Profits.calculateLv1Profit(board), 0.0);
+    Tests.equals(Profits.calculateLv1Profit(board), 0.08);
     board.cells[8].type = 'blueberries';
-    Tests.equals(Profits.calculateLv1Profit(board), 0.0);
+    Tests.equals(Profits.calculateLv1Profit(board), 0.09);
   }
 
 ]);


### PR DESCRIPTION
When there are no trees, blueberry bushes provide $0. This may be
confusing for new players as their actions don't seem to have any
effect.

The minimum multiplier is small to ensure that adding the first tree
will always result in a profit increase. Though, perhaps alternative
profit functions should be considered to keep the value of tree-less
blueberry bushes identical across levels 1, 2 and 3.